### PR TITLE
Add CodExpress landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# codexpress
+# CodExpress Landing
+
+Landing page oscura y futurista para la competencia de programación CodExpress 2025 organizada por Computer Society UNAL.
+
+## Visualizar
+
+Abre `index.html` en tu navegador favorito. No se requieren dependencias ni build tools.

--- a/assets/qr-inscripcion.svg
+++ b/assets/qr-inscripcion.svg
@@ -1,0 +1,42 @@
+<svg width="280" height="280" viewBox="0 0 280 280" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">QR CodExpress Inscripción</title>
+  <desc id="desc">Representación visual estilo código QR para la inscripción a CodExpress 2025</desc>
+  <rect width="280" height="280" fill="#040908" rx="24"/>
+  <rect x="12" y="12" width="84" height="84" fill="none" stroke="#00FF7F" stroke-width="8" rx="12"/>
+  <rect x="28" y="28" width="52" height="52" fill="#00FF7F" rx="8"/>
+  <rect x="36" y="36" width="36" height="36" fill="#040908" rx="6"/>
+
+  <rect x="184" y="12" width="84" height="84" fill="none" stroke="#00FF7F" stroke-width="8" rx="12"/>
+  <rect x="200" y="28" width="52" height="52" fill="#00FF7F" rx="8"/>
+  <rect x="208" y="36" width="36" height="36" fill="#040908" rx="6"/>
+
+  <rect x="12" y="184" width="84" height="84" fill="none" stroke="#00FF7F" stroke-width="8" rx="12"/>
+  <rect x="28" y="200" width="52" height="52" fill="#00FF7F" rx="8"/>
+  <rect x="36" y="208" width="36" height="36" fill="#040908" rx="6"/>
+
+  <g fill="#00FF7F">
+    <rect x="120" y="32" width="16" height="16" rx="3"/>
+    <rect x="152" y="48" width="16" height="16" rx="3"/>
+    <rect x="120" y="80" width="16" height="16" rx="3"/>
+    <rect x="136" y="96" width="16" height="16" rx="3"/>
+    <rect x="168" y="96" width="16" height="16" rx="3"/>
+    <rect x="120" y="128" width="16" height="16" rx="3"/>
+    <rect x="152" y="128" width="16" height="16" rx="3"/>
+    <rect x="184" y="128" width="16" height="16" rx="3"/>
+    <rect x="88" y="136" width="16" height="16" rx="3"/>
+    <rect x="56" y="152" width="16" height="16" rx="3"/>
+    <rect x="120" y="160" width="16" height="16" rx="3"/>
+    <rect x="152" y="176" width="16" height="16" rx="3"/>
+    <rect x="88" y="184" width="16" height="16" rx="3"/>
+    <rect x="136" y="200" width="16" height="16" rx="3"/>
+    <rect x="168" y="216" width="16" height="16" rx="3"/>
+    <rect x="200" y="200" width="16" height="16" rx="3"/>
+    <rect x="232" y="168" width="16" height="16" rx="3"/>
+    <rect x="200" y="152" width="16" height="16" rx="3"/>
+    <rect x="232" y="120" width="16" height="16" rx="3"/>
+    <rect x="200" y="96" width="16" height="16" rx="3"/>
+    <rect x="168" y="152" width="16" height="16" rx="3"/>
+    <rect x="104" y="200" width="16" height="16" rx="3"/>
+    <rect x="72" y="232" width="16" height="16" rx="3"/>
+  </g>
+</svg>

--- a/assets/qr-tallerista.svg
+++ b/assets/qr-tallerista.svg
@@ -1,0 +1,44 @@
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">QR propuestas de talleres CodExpress</title>
+  <desc id="desc">Código QR estilizado para el formulario de propuestas de talleres CodExpress</desc>
+  <rect width="240" height="240" fill="#030707" rx="20"/>
+  <rect x="10" y="10" width="70" height="70" fill="none" stroke="#00FF7F" stroke-width="7" rx="10"/>
+  <rect x="24" y="24" width="42" height="42" fill="#00FF7F" rx="7"/>
+  <rect x="32" y="32" width="26" height="26" fill="#030707" rx="5"/>
+
+  <rect x="160" y="10" width="70" height="70" fill="none" stroke="#00FF7F" stroke-width="7" rx="10"/>
+  <rect x="174" y="24" width="42" height="42" fill="#00FF7F" rx="7"/>
+  <rect x="182" y="32" width="26" height="26" fill="#030707" rx="5"/>
+
+  <rect x="10" y="160" width="70" height="70" fill="none" stroke="#00FF7F" stroke-width="7" rx="10"/>
+  <rect x="24" y="174" width="42" height="42" fill="#00FF7F" rx="7"/>
+  <rect x="32" y="182" width="26" height="26" fill="#030707" rx="5"/>
+
+  <g fill="#00FF7F">
+    <rect x="108" y="24" width="14" height="14" rx="3"/>
+    <rect x="136" y="46" width="14" height="14" rx="3"/>
+    <rect x="108" y="74" width="14" height="14" rx="3"/>
+    <rect x="136" y="88" width="14" height="14" rx="3"/>
+    <rect x="108" y="102" width="14" height="14" rx="3"/>
+    <rect x="150" y="116" width="14" height="14" rx="3"/>
+    <rect x="122" y="130" width="14" height="14" rx="3"/>
+    <rect x="94" y="130" width="14" height="14" rx="3"/>
+    <rect x="66" y="116" width="14" height="14" rx="3"/>
+    <rect x="122" y="158" width="14" height="14" rx="3"/>
+    <rect x="150" y="172" width="14" height="14" rx="3"/>
+    <rect x="94" y="172" width="14" height="14" rx="3"/>
+    <rect x="136" y="186" width="14" height="14" rx="3"/>
+    <rect x="108" y="200" width="14" height="14" rx="3"/>
+    <rect x="166" y="200" width="14" height="14" rx="3"/>
+    <rect x="194" y="172" width="14" height="14" rx="3"/>
+    <rect x="208" y="144" width="14" height="14" rx="3"/>
+    <rect x="180" y="130" width="14" height="14" rx="3"/>
+    <rect x="208" y="102" width="14" height="14" rx="3"/>
+    <rect x="166" y="88" width="14" height="14" rx="3"/>
+    <rect x="52" y="144" width="14" height="14" rx="3"/>
+    <rect x="38" y="116" width="14" height="14" rx="3"/>
+    <rect x="52" y="88" width="14" height="14" rx="3"/>
+    <rect x="80" y="60" width="14" height="14" rx="3"/>
+    <rect x="122" y="46" width="14" height="14" rx="3"/>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,724 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CodExpress 2025 – Competencia de programación</title>
+  <meta name="description" content="CodExpress 2025, competencia de programación híbrida organizada por Computer Society UNAL. Descubre cómo participar, niveles, talleres y premios.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Chakra+Petch:wght@600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #050505;
+      --bg-alt: #0d1012;
+      --bg-soft: #11171c;
+      --accent: #00FF7F;
+      --accent-soft: rgba(0, 255, 127, 0.2);
+      --text: #f2f5f4;
+      --muted: #9da6aa;
+      --card-border: rgba(0, 255, 127, 0.25);
+      --shadow: 0 25px 60px rgba(0, 255, 127, 0.15);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Space Grotesk', 'Chakra Petch', 'Segoe UI', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.7;
+      letter-spacing: 0.01em;
+      overflow-x: hidden;
+    }
+
+    h1, h2, h3, h4 {
+      font-family: 'Chakra Petch', 'Space Grotesk', 'Segoe UI', sans-serif;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    h2 {
+      font-size: clamp(2rem, 4vw, 2.8rem);
+      margin-bottom: 0.8rem;
+    }
+
+    p {
+      max-width: 65ch;
+      color: var(--muted);
+    }
+
+    section {
+      padding: 5rem 0;
+      position: relative;
+    }
+
+    .container {
+      width: min(1200px, 90vw);
+      margin: 0 auto;
+    }
+
+    .hero {
+      min-height: 100vh;
+      display: grid;
+      align-items: center;
+      justify-items: center;
+      text-align: center;
+      padding: 6rem 0 4rem;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero::before,
+    .hero::after {
+      content: "";
+      position: absolute;
+      width: 60vw;
+      height: 60vw;
+      max-width: 900px;
+      max-height: 900px;
+      background: radial-gradient(circle, rgba(0, 255, 127, 0.25) 0%, rgba(0, 255, 127, 0.05) 60%, rgba(0, 0, 0, 0) 75%);
+      filter: blur(60px);
+      z-index: -2;
+    }
+
+    .hero::before {
+      top: -20vh;
+      left: -20vw;
+    }
+
+    .hero::after {
+      bottom: -25vh;
+      right: -15vw;
+    }
+
+    .hero__panel {
+      background: rgba(5, 5, 5, 0.65);
+      backdrop-filter: blur(24px);
+      border: 1px solid rgba(0, 255, 127, 0.25);
+      border-radius: 28px;
+      padding: clamp(2.5rem, 5vw, 4rem);
+      box-shadow: var(--shadow);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero__panel::before {
+      content: "{ CODE IN MOTION }";
+      position: absolute;
+      top: 18px;
+      left: 50%;
+      transform: translateX(-50%);
+      font-size: 0.85rem;
+      letter-spacing: 0.4em;
+      color: rgba(0, 255, 127, 0.45);
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+
+    .hero h1 {
+      font-size: clamp(3.8rem, 11vw, 7rem);
+      margin: 0 0 1rem;
+      color: var(--text);
+      text-shadow: 0 0 22px rgba(0, 255, 127, 0.25);
+    }
+
+    .hero h1 span {
+      display: block;
+      font-size: clamp(1.15rem, 2vw, 1.4rem);
+      letter-spacing: 0.7em;
+      color: rgba(0, 255, 127, 0.65);
+      margin-bottom: 0.9rem;
+    }
+
+    .hero__subtitle {
+      font-size: clamp(1.2rem, 2.3vw, 1.6rem);
+      color: rgba(242, 245, 244, 0.82);
+      margin-bottom: 1.5rem;
+    }
+
+    .hero__meta {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 1.5rem;
+      margin: 2rem 0 2.75rem;
+    }
+
+    .meta-pill {
+      border: 1px solid rgba(0, 255, 127, 0.4);
+      border-radius: 999px;
+      padding: 0.75rem 1.5rem;
+      font-size: 0.95rem;
+      letter-spacing: 0.2em;
+      color: rgba(255, 255, 255, 0.8);
+      background: rgba(17, 23, 28, 0.8);
+    }
+
+    .hero__buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      justify-content: center;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.4rem;
+      padding: 0.95rem 2.6rem;
+      border-radius: 999px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.2em;
+      font-size: 0.95rem;
+      border: none;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #030303;
+      box-shadow: 0 15px 40px rgba(0, 255, 127, 0.45);
+    }
+
+    .btn-primary:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 20px 48px rgba(0, 255, 127, 0.55);
+    }
+
+    .btn-ghost {
+      background: rgba(0, 0, 0, 0.35);
+      border: 1px solid rgba(0, 255, 127, 0.45);
+      color: var(--text);
+    }
+
+    .btn-ghost:hover {
+      transform: translateY(-3px);
+      background: rgba(0, 255, 127, 0.1);
+    }
+
+    .section-title {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      letter-spacing: 0.35em;
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      margin-bottom: 1rem;
+      color: rgba(0, 255, 127, 0.7);
+    }
+
+    .section-title::before {
+      content: "\\25BA";
+      font-size: 0.8rem;
+      color: rgba(0, 255, 127, 0.8);
+    }
+
+    .terminal-banner {
+      font-family: 'Chakra Petch', monospace;
+      background: linear-gradient(90deg, rgba(0, 255, 127, 0.25), rgba(0, 255, 127, 0));
+      border-left: 4px solid var(--accent);
+      padding: 0.85rem 1.2rem;
+      margin-bottom: 2rem;
+      color: rgba(255, 255, 255, 0.85);
+      text-transform: uppercase;
+      letter-spacing: 0.3em;
+    }
+
+    .two-column {
+      display: grid;
+      gap: 2.8rem;
+      align-items: center;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+
+    .ascii-art {
+      font-family: "Cascadia Mono", "Fira Code", monospace;
+      font-size: 1rem;
+      line-height: 1.2;
+      color: rgba(0, 255, 127, 0.8);
+      background: rgba(4, 8, 10, 0.8);
+      border: 1px solid rgba(0, 255, 127, 0.25);
+      border-radius: 18px;
+      padding: 1.8rem;
+      box-shadow: var(--shadow);
+    }
+
+    .participar-grid {
+      display: grid;
+      gap: 3rem;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      align-items: center;
+    }
+
+    .steps {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      counter-reset: pasos;
+      display: flex;
+      flex-direction: column;
+      gap: 1.2rem;
+    }
+
+    .steps li {
+      counter-increment: pasos;
+      background: rgba(9, 14, 16, 0.9);
+      border: 1px solid rgba(0, 255, 127, 0.25);
+      border-radius: 20px;
+      padding: 1.4rem 1.8rem 1.4rem 4.2rem;
+      position: relative;
+      line-height: 1.6;
+      color: rgba(239, 243, 242, 0.85);
+    }
+
+    .steps li::before {
+      content: "0" counter(pasos);
+      position: absolute;
+      left: 1.4rem;
+      top: 1.15rem;
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: var(--accent);
+      letter-spacing: 0.2em;
+    }
+
+    .steps strong {
+      display: block;
+      font-size: 1.05rem;
+      color: var(--text);
+      letter-spacing: 0.12em;
+      margin-bottom: 0.4rem;
+    }
+
+    .qr-card {
+      background: rgba(4, 6, 8, 0.9);
+      border-radius: 24px;
+      border: 1px solid rgba(0, 255, 127, 0.25);
+      padding: 2rem;
+      text-align: center;
+      box-shadow: var(--shadow);
+    }
+
+    .qr-card img {
+      width: min(240px, 70%);
+      aspect-ratio: 1;
+      margin-bottom: 1rem;
+      border-radius: 16px;
+      border: 8px solid rgba(0, 255, 127, 0.15);
+      background: rgba(0, 255, 127, 0.05);
+    }
+
+    .qr-card .qr-label {
+      text-transform: uppercase;
+      letter-spacing: 0.3em;
+      font-size: 0.75rem;
+      color: rgba(255, 255, 255, 0.65);
+    }
+
+    .levels {
+      background: #0b0d10;
+      border-radius: 32px;
+      padding: 3.5rem 3rem;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .levels::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(120deg, rgba(0, 255, 127, 0.08), transparent 45%);
+      opacity: 0.6;
+      pointer-events: none;
+    }
+
+    .level-grid {
+      display: grid;
+      gap: 1.8rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      position: relative;
+      z-index: 1;
+    }
+
+    .level-card {
+      background: rgba(5, 7, 9, 0.85);
+      border: 1px solid var(--card-border);
+      border-radius: 22px;
+      padding: 1.8rem;
+      min-height: 220px;
+      box-shadow: 0 18px 36px rgba(0, 0, 0, 0.4);
+      display: flex;
+      flex-direction: column;
+      gap: 0.8rem;
+    }
+
+    .level-card h3 {
+      font-size: 1rem;
+      letter-spacing: 0.18em;
+      color: var(--accent);
+      margin: 0;
+    }
+
+    .level-card p {
+      color: rgba(220, 231, 228, 0.9);
+      margin: 0;
+    }
+
+    .resources-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1.8rem;
+    }
+
+    .resource-card {
+      background: rgba(7, 10, 11, 0.9);
+      border-radius: 20px;
+      padding: 1.6rem;
+      border: 1px solid rgba(0, 255, 127, 0.2);
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+      transition: transform 0.2s ease, border 0.2s ease;
+    }
+
+    .resource-card:hover {
+      transform: translateY(-6px);
+      border-color: rgba(0, 255, 127, 0.5);
+    }
+
+    .resource-card .resource-icon {
+      width: 48px;
+      height: 48px;
+      border-radius: 16px;
+      display: grid;
+      place-items: center;
+      background: rgba(0, 255, 127, 0.1);
+      border: 1px solid rgba(0, 255, 127, 0.3);
+      color: var(--accent);
+      font-size: 1.4rem;
+      font-family: 'Chakra Petch', monospace;
+    }
+
+    .benefits {
+      background: rgba(5, 7, 9, 0.8);
+      border-radius: 28px;
+      border: 1px solid rgba(0, 255, 127, 0.25);
+      padding: 2.6rem;
+      box-shadow: var(--shadow);
+    }
+
+    .benefits ul {
+      list-style: none;
+      padding: 0;
+      margin: 2rem 0 0;
+      display: grid;
+      gap: 1rem;
+    }
+
+    .benefits li {
+      font-size: 1rem;
+      color: rgba(232, 238, 236, 0.9);
+      letter-spacing: 0.05em;
+    }
+
+    .talleres {
+      background: rgba(2, 4, 5, 0.92);
+      border-radius: 26px;
+      border: 1px solid rgba(0, 255, 127, 0.2);
+      padding: 3rem;
+      display: grid;
+      gap: 2rem;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      align-items: center;
+    }
+
+    .qr-mini {
+      text-align: center;
+    }
+
+    .qr-mini img {
+      width: 180px;
+      height: 180px;
+      border-radius: 16px;
+      border: 6px solid rgba(0, 255, 127, 0.2);
+      background: rgba(0, 255, 127, 0.05);
+      margin-bottom: 0.75rem;
+    }
+
+    .cta-final {
+      background: radial-gradient(circle at top, rgba(0, 255, 127, 0.25), rgba(5, 5, 5, 0.95));
+      text-align: center;
+      padding: 5rem 1rem 6rem;
+      border-radius: 36px;
+      border: 1px solid rgba(0, 255, 127, 0.2);
+      box-shadow: var(--shadow);
+    }
+
+    .cta-final h2 {
+      font-size: clamp(2.6rem, 6vw, 4.4rem);
+      letter-spacing: 0.5em;
+      margin-bottom: 1rem;
+    }
+
+    .cta-final p {
+      margin: 0 auto 2.5rem;
+      max-width: 50ch;
+      color: rgba(240, 245, 244, 0.8);
+    }
+
+    footer {
+      margin-top: 4rem;
+      padding: 2.5rem 0 3rem;
+      border-top: 1px solid rgba(0, 255, 127, 0.15);
+      text-align: center;
+      color: rgba(150, 160, 162, 0.75);
+      font-size: 0.9rem;
+      letter-spacing: 0.15em;
+    }
+
+    .footer__logo {
+      font-size: 1.2rem;
+      font-weight: 700;
+      letter-spacing: 0.45em;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.85);
+      margin-bottom: 1.2rem;
+      display: inline-block;
+    }
+
+    .footer__links {
+      display: flex;
+      justify-content: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 1.2rem;
+    }
+
+    .footer__links a {
+      color: rgba(255, 255, 255, 0.75);
+      text-decoration: none;
+      font-weight: 600;
+      letter-spacing: 0.2em;
+    }
+
+    .footer__links a:hover {
+      color: var(--accent);
+    }
+
+    .tiny-note {
+      margin-top: 1.5rem;
+      font-size: 0.75rem;
+      color: rgba(130, 140, 142, 0.75);
+      letter-spacing: 0.08em;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    @media (max-width: 640px) {
+      section {
+        padding: 4rem 0;
+      }
+
+      .hero__panel {
+        padding: 2.2rem 1.6rem 3rem;
+      }
+
+      .hero h1 {
+        letter-spacing: 0.12em;
+      }
+
+      .hero__meta {
+        gap: 0.8rem;
+      }
+
+      .cta-final h2 {
+        letter-spacing: 0.3em;
+      }
+
+      footer {
+        letter-spacing: 0.08em;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero__panel">
+      <h1><span>&lt; CodExpress /&gt;</span>CodExpress 2025</h1>
+      <p class="hero__subtitle">Una tarde, mil soluciones.</p>
+      <p>Competencia de programación organizada por Computer Society UNAL. Abierta a todos los niveles, desde principiantes hasta avanzados.</p>
+      <div class="hero__meta">
+        <span class="meta-pill">3 de Octubre · 2:00 PM</span>
+        <span class="meta-pill">Modalidad Híbrida · UNAL + Online</span>
+      </div>
+      <div class="hero__buttons">
+        <a class="btn btn-primary" href="https://luma.com/45x25kxk" target="_blank" rel="noopener">Inscribirme ahora</a>
+        <a class="btn btn-ghost" href="https://luma.com/utavo1x6" target="_blank" rel="noopener">Registro Externos</a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section id="que-es">
+      <div class="container">
+        <div class="section-title">¿Qué es CodExpress?</div>
+        <div class="two-column">
+          <div>
+            <div class="terminal-banner">/** Enciende tu modo competitivo */</div>
+            <p>CodExpress es una competencia de programación del capítulo estudiantil Computer Society UNAL. Su propósito es desafiar las habilidades de los estudiantes y mostrar cómo los aprendizajes en matemáticas y física se relacionan con la computación.</p>
+          </div>
+          <pre aria-hidden="true" class="ascii-art">
+   ______      ____   _________
+  / ____/___  / __/  / ____/   |  
+ / /   / __ \/ /_   / /   / /| |  
+/ /___/ /_/ / __/  / /___/ ___ |  
+\____/\____/_/     \____/_/  |_|  
+{   CODExpress   }</pre>
+        </div>
+      </div>
+    </section>
+
+    <section id="como-participar">
+      <div class="container">
+        <div class="section-title">Cómo participar</div>
+        <div class="participar-grid">
+          <ol class="steps">
+            <li>
+              <strong>Regístrate en Luma</strong>
+              Selecciona tu categoría: estudiantes UNAL o participantes externos.
+            </li>
+            <li>
+              <strong>Realiza el pago de la inscripción</strong>
+              Estudiantes UNAL: 5.000 COP · Externos: 10.000 COP.
+            </li>
+            <li>
+              <strong>Prepárate para el 3 de octubre</strong>
+              Organiza tu equipo, revisa los recursos y activa tu modo resolución.
+            </li>
+          </ol>
+          <div class="qr-card">
+            <img src="assets/qr-inscripcion.svg" alt="Código QR para la inscripción a CodExpress">
+            <div class="qr-label">Escanéalo desde tu móvil</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="niveles">
+      <div class="container levels">
+        <div class="section-title">Niveles de competencia</div>
+        <div class="level-grid">
+          <article class="level-card">
+            <h3>Nivel Básico</h3>
+            <p>Fundamentos y lógica de programación. Simuladores matemáticos simples y lógica en Python.</p>
+            <p><strong>Relación con cursos:</strong> Fundamentos de matemáticas, Programación I.</p>
+          </article>
+          <article class="level-card">
+            <h3>Nivel Intermedio</h3>
+            <p>Estructuras de datos y POO inicial. Proyectos en Python, Java o C++.</p>
+            <p><strong>Ejemplos:</strong> sistema de colas, agendas académicas.</p>
+          </article>
+          <article class="level-card">
+            <h3>Nivel Avanzado Ligero</h3>
+            <p>Algoritmos y eficiencia con énfasis en BFS/DFS y optimización en Python y C++.</p>
+            <p><strong>Relación con cursos:</strong> Algoritmos, Matemáticas discretas.</p>
+          </article>
+          <article class="level-card">
+            <h3>Integración y Sistemas</h3>
+            <p>Aplicaciones completas y multidisciplinarias con bases de datos y APIs (Python + JavaScript).</p>
+            <p><strong>Ejemplo:</strong> sistema CRUD, chat simple, integración de servicios.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="recursos">
+      <div class="container">
+        <div class="section-title">Recursos de preparación</div>
+        <div class="resources-grid">
+          <article class="resource-card">
+            <div class="resource-icon">▶</div>
+            <h3>Playlist Python UNAL</h3>
+            <p><a href="https://www.youtube.com" target="_blank" rel="noopener">Playlist de fundamentos en Python (UNAL)</a>.</p>
+          </article>
+          <article class="resource-card">
+            <div class="resource-icon">◈</div>
+            <h3>Programming for Everybody</h3>
+            <p><a href="https://www.coursera.org/learn/python" target="_blank" rel="noopener">Curso “Programming for Everybody” – Univ. of Michigan</a>.</p>
+          </article>
+          <article class="resource-card">
+            <div class="resource-icon">⌘</div>
+            <h3>Data Structures &amp; Algorithms</h3>
+            <p><a href="https://www.coursera.org/specializations/data-structures-algorithms" target="_blank" rel="noopener">Especialización – UC San Diego</a>.</p>
+          </article>
+          <article class="resource-card">
+            <div class="resource-icon">DB</div>
+            <h3>Bases de datos en SQL</h3>
+            <p><a href="https://www.coursera.org/learn/sql-data-science" target="_blank" rel="noopener">Bases de datos en SQL con Python – IBM</a>.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="beneficios">
+      <div class="container benefits">
+        <h2>Compite, aprende y gana.</h2>
+        <p>Vive la experiencia CodExpress con comunidad, mentoría y sorpresas diseñadas para impulsar tu camino en la computación.</p>
+        <ul>
+          <li>🎓 Certificados de participación.</li>
+          <li>✨ Agendas, esferos y detalles del capítulo estudiantil.</li>
+          <li>💰 Premios en efectivo (hasta 50.000 COP).</li>
+          <li>🌍 Aporte a la financiación de proyectos estudiantiles en IA y computación cuántica.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="talleres">
+      <div class="container talleres">
+        <div>
+          <div class="section-title">Talleres relacionados</div>
+          <p>Antes y durante el evento realizaremos talleres prácticos sobre Python, algoritmos, APIs, inteligencia artificial y consejos para ganar competencias de programación. Abiertos a todo público.</p>
+          <a class="btn btn-ghost" href="https://forms.gle/CodExpressTalleristas" target="_blank" rel="noopener">Quiero ser tallerista</a>
+        </div>
+        <div class="qr-mini">
+          <img src="assets/qr-tallerista.svg" alt="QR para enviar propuestas de talleres">
+          <div class="qr-label">qr-tallerista</div>
+        </div>
+      </div>
+    </section>
+
+    <section id="cta-final">
+      <div class="container cta-final">
+        <h2>¿Listo para el reto?</h2>
+        <p>CodExpress te espera este 3 de octubre. Inscríbete y demuestra tu talento.</p>
+        <div class="hero__buttons">
+          <a class="btn btn-primary" href="https://luma.com/45x25kxk" target="_blank" rel="noopener">Inscribirme en Luma</a>
+          <a class="btn btn-ghost" href="https://luma.com/utavo1x6" target="_blank" rel="noopener">Registro Externos</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer__logo">Computer Society UNAL</div>
+    <div>Contacto: <a href="mailto:computer_fbog@unal.edu.co">computer_fbog@unal.edu.co</a></div>
+    <div class="footer__links">
+      <a href="https://instagram.com" target="_blank" rel="noopener" aria-label="Instagram">Instagram</a>
+      <a href="https://www.facebook.com" target="_blank" rel="noopener" aria-label="Facebook">Facebook</a>
+      <a href="https://www.linkedin.com" target="_blank" rel="noopener" aria-label="LinkedIn">LinkedIn</a>
+    </div>
+    <div class="tiny-note">Evento estudiantil sin ánimo de lucro. Los aportes recaudados apoyan la investigación y la participación en eventos internacionales.</div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a dark, neon-accent landing page for CodExpress 2025 with hero, participation details, levels, recursos, beneficios y talleres
- add stylized SVG QR placeholders for la inscripción general y propuestas de talleres
- update README with quick instructions for visualizar el sitio

## Testing
- not run (static HTML project)


------
https://chatgpt.com/codex/tasks/task_e_68cc105d43c08329b383d9a06d16d876